### PR TITLE
Fix UMO historical BIP30 duplicate handling

### DIFF
--- a/src/kernel/coinstats.h
+++ b/src/kernel/coinstats.h
@@ -59,7 +59,7 @@ struct CCoinsStats {
     CAmount total_coinbase_amount{0};
     //! The unspendable coinbase amount from the genesis block
     CAmount total_unspendables_genesis_block{0};
-    //! The two unspendable coinbase outputs total amount caused by BIP30
+    //! Unspendable coinbase output amounts caused by historical BIP30 duplicates
     CAmount total_unspendables_bip30{0};
     //! Total cumulative amount of outputs sent to unspendable scripts (OP_RETURN for example) up to and including this block
     CAmount total_unspendables_scripts{0};

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1999,8 +1999,7 @@ DisconnectResult Chainstate::DisconnectBlock(const CBlock& block, const CBlockIn
     // Note: the blocks specified here are different than the ones used in ConnectBlock because DisconnectBlock
     // unwinds the blocks in reverse. As a result, the inconsistency is not discovered until the earlier
     // blocks with the duplicate coinbase transactions are disconnected.
-    bool fEnforceBIP30 = !((pindex->nHeight==91722 && pindex->GetBlockHash() == uint256S("0x00000000000271a2dc26e7667f8419f2e15416dc6955e5a6c6cdf3f2574dd08e")) ||
-                           (pindex->nHeight==91812 && pindex->GetBlockHash() == uint256S("0x00000000000af0aed4792b1acee3d966af36cf5def14935db8de83d6f9306f2f")));
+    bool fEnforceBIP30 = !IsBIP30Unspendable(*pindex);
 
     // undo transactions in reverse order
     for (int i = block.vtx.size() - 1; i >= 0; i--) {
@@ -5784,14 +5783,19 @@ Chainstate& ChainstateManager::ActivateExistingSnapshot(CTxMemPool* mempool, uin
 
 bool IsBIP30Repeat(const CBlockIndex& block_index)
 {
-    return (block_index.nHeight==91842 && block_index.GetBlockHash() == uint256S("0x00000000000a4d0a398161ffc163c503763b1f4360639393e0e4c8e300e0caec")) ||
-           (block_index.nHeight==91880 && block_index.GetBlockHash() == uint256S("0x00000000000743f190a18c5577a3c2d2a1f610ae9601ac046a38084ccb7cd721"));
+    // UMO mainnet duplicate-coinbase history. This later block repeats the
+    // prior height-206688 coinbase txid; ConnectBlock exempts only this exact
+    // height/hash pair from the BIP30 overwrite check.
+    return block_index.nHeight == 206689 &&
+           block_index.GetBlockHash() == uint256S("0xbef4e3fa7af68826e18264f4f4a1ad510e0c881cb5a9c8fde02f190f1da74f7c");
 }
 
 bool IsBIP30Unspendable(const CBlockIndex& block_index)
 {
-    return (block_index.nHeight==91722 && block_index.GetBlockHash() == uint256S("0x00000000000271a2dc26e7667f8419f2e15416dc6955e5a6c6cdf3f2574dd08e")) ||
-           (block_index.nHeight==91812 && block_index.GetBlockHash() == uint256S("0x00000000000af0aed4792b1acee3d966af36cf5def14935db8de83d6f9306f2f"));
+    // Earlier block whose coinbase output becomes unspendable because the
+    // next block repeats the coinbase txid.
+    return block_index.nHeight == 206688 &&
+           block_index.GetBlockHash() == uint256S("0x098ec09671474fbc06bd577f8c8b0b9bdeb79f997b0e5d5b8a1bd1b5c3974e3d");
 }
 
 void Chainstate::InvalidateCoinsDBOnDisk()


### PR DESCRIPTION
Record the UniversalMolecule mainnet duplicate coinbase pair at heights 206688 and 206689, and use the chain-specific unspendable helper during disconnect validation.

This keeps BIP30 validation active everywhere except the exact historical duplicate blocks needed for mainnet replay.