### PR TITLE
Restore snapshot service advertising

### DIFF
--- a/contrib/linearize/example-linearize.cfg
+++ b/contrib/linearize/example-linearize.cfg
@@ -6,14 +6,14 @@ host=127.0.0.1
 port=5921
 
 min_height=0
-max_height=4121537
+max_height=4121601
 
 netmagic=fad3e7f4
 genesis=00000059f24d9e85501bd3873fac0cd6e8a43fd8c20eee856082dbdcc09a8e64
 input=/home/example/.universalmolecule/blocks
 
 hashlist=hashlist.txt
-output_file=/home/example/universalmolecule-bootstrap-4121537.dat
+output_file=/home/example/universalmolecule-bootstrap-4121601.dat
 
 out_of_order_cache_sz=100000000
 rev_hash_bytes=False

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1491,6 +1491,14 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
 
         node.chainman = std::make_unique<ChainstateManager>(chainman_opts, blockman_opts);
         ChainstateManager& chainman = *node.chainman;
+        chainman.snapshot_validation_completed = [&node]() {
+            if (!Assert(node.chainman)->m_blockman.IsPruneMode()) {
+                LogPrintf("[snapshot] re-enabling NODE_NETWORK services\n");
+                if (node.connman) {
+                    node.connman->AddLocalServices(NODE_NETWORK);
+                }
+            }
+        };
 
         node::ChainstateLoadOptions options;
         options.mempool = Assert(node.mempool.get());
@@ -1616,8 +1624,13 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
             }
         }
     } else {
-        LogPrintf("Setting NODE_NETWORK on non-prune mode\n");
-        nLocalServices = ServiceFlags(nLocalServices | NODE_NETWORK);
+        const bool snapshot_pending_validation{WITH_LOCK(cs_main, return chainman.IsSnapshotActive() && !chainman.IsSnapshotValidated())};
+        if (snapshot_pending_validation) {
+            LogPrintf("Running node in NODE_NETWORK_LIMITED mode until snapshot background validation completes\n");
+        } else {
+            LogPrintf("Setting NODE_NETWORK on non-prune mode\n");
+            nLocalServices = ServiceFlags(nLocalServices | NODE_NETWORK);
+        }
     }
 
     // ********************************************************* Step 11: import blocks

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5694,6 +5694,9 @@ SnapshotCompletionResult ChainstateManager::MaybeCompleteSnapshotValidation(
 
     m_ibd_chainstate->m_disabled = true;
     this->MaybeRebalanceCaches();
+    if (snapshot_validation_completed) {
+        snapshot_validation_completed();
+    }
 
     return SnapshotCompletionResult::SUCCESS;
 }

--- a/src/validation.h
+++ b/src/validation.h
@@ -35,6 +35,7 @@
 #include <versionbits.h>
 
 #include <atomic>
+#include <functional>
 #include <map>
 #include <memory>
 #include <optional>
@@ -957,6 +958,9 @@ public:
     using Options = kernel::ChainstateManagerOpts;
 
     explicit ChainstateManager(Options options, node::BlockManager::Options blockman_options);
+
+    //! Called after a loaded snapshot has been fully validated by the background chainstate.
+    std::function<void()> snapshot_validation_completed;
 
     const CChainParams& GetParams() const { return m_options.chainparams; }
     const Consensus::Params& GetConsensus() const { return m_options.chainparams.GetConsensus(); }


### PR DESCRIPTION
Re-enable NODE_NETWORK after assumeutxo background validation completes on non-pruned nodes.

Keep startup in NODE_NETWORK_LIMITED while snapshot validation is pending and align the linearize example height with the UMO assumeutxo metadata.