### PR TITLE
universalmol 0.25.2: AuxPoW version-gate GetBaseVersion fix, consensu…

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2116,6 +2116,9 @@ fi
 # tree is forced through C++11. Moving the Windows cross-build to C++17 avoids
 # those multiple-definition link failures without changing other host paths.
 find . -name Makefile -type f -exec sed -i "s/-std=c++11/-std=c++17/g" {} +
+# MXE mingw g++ rejects this C-only precision flag for C++; keep the other
+# floating-point determinism flags intact.
+find . -name Makefile -type f -exec sed -i "s/ -fexcess-precision=standard//g" {} +
 
 # Fix missing Qt translation files (UniversalMolecule fork does not include them)
 if [ -f src/Makefile ]; then
@@ -2840,6 +2843,10 @@ echo ">>> Building Qt wallet with autotools..."
 ./autogen.sh
 ./configure --disable-tests --disable-bench --disable-fuzz-binary --enable-upnp-default \
     CXXFLAGS="-O2 -DBOOST_BIND_GLOBAL_PLACEHOLDERS" LDFLAGS="-static-libstdc++"
+
+# The AppImage base compiler can reject this C-only precision flag for C++.
+# Keep the other floating-point determinism flags intact.
+find . -name Makefile -type f -exec sed -i "s/ -fexcess-precision=standard//g" {} +
 
 # Fix missing Qt translation files (UniversalMolecule fork does not include them)
 if [ -f src/Makefile ]; then

--- a/configure.ac
+++ b/configure.ac
@@ -1923,6 +1923,24 @@ AC_SUBST(BITCOIN_WALLET_TOOL_NAME)
 AC_SUBST(BITCOIN_MP_NODE_NAME)
 AC_SUBST(BITCOIN_MP_GUI_NAME)
 
+dnl ---- Consensus-critical floating-point determinism (universalmol) ----
+dnl universalmol's block subsidy (GetBlockSubsidy via LegacyRewardDifficultyTrendIsRising
+dnl in src/validation.cpp) picks a consensus reward (0.1 vs 2 UMO) from an IEEE-754
+dnl floating-point difficulty comparison. Every validator must reproduce a byte-identical
+dnl result or the chain forks, so the build must keep strict IEEE-754 semantics. Refuse
+dnl known-unsafe flags, then pin the deterministic ones. The pins are already the effective
+dnl defaults on x86-64; pinning them stops a future toolchain/CI change from silently
+dnl breaking consensus. AX_CHECK_COMPILE_FLAG skips any flag the target compiler rejects
+dnl (e.g. -msse2/-mfpmath on non-x86, or -fexcess-precision on clang).
+case " $CXXFLAGS $CFLAGS $CPPFLAGS $CORE_CXXFLAGS " in
+  *" -ffast-math "*|*" -Ofast "*|*" -funsafe-math-optimizations "*|*" -ffp-contract=fast "*)
+    AC_MSG_ERROR([refusing to build with non-IEEE-754 floating point (-ffast-math / -Ofast / -funsafe-math-optimizations / -ffp-contract=fast): universalmol's consensus block subsidy depends on deterministic IEEE-754 results. Remove the flag.])
+  ;;
+esac
+AX_CHECK_COMPILE_FLAG([-ffp-contract=off], [CORE_CXXFLAGS="$CORE_CXXFLAGS -ffp-contract=off"], [], [$CXXFLAG_WERROR])
+AX_CHECK_COMPILE_FLAG([-fexcess-precision=standard], [CORE_CXXFLAGS="$CORE_CXXFLAGS -fexcess-precision=standard"], [], [$CXXFLAG_WERROR])
+AX_CHECK_COMPILE_FLAG([-msse2 -mfpmath=sse], [CORE_CXXFLAGS="$CORE_CXXFLAGS -msse2 -mfpmath=sse"], [], [$CXXFLAG_WERROR])
+
 AC_SUBST(RELDFLAGS)
 AC_SUBST(CORE_LDFLAGS)
 AC_SUBST(CORE_CPPFLAGS)

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2257,6 +2257,17 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
                                           pindex->nHeight < params.GetConsensus().BIP34Height;
     bool fEnforceBIP30 = !legacy_mainnet_pre_bip34 && !IsBIP30Repeat(*pindex);
 
+    // NOTE (universalmol): the comment block below is inherited verbatim from
+    // Bitcoin Core and describes *Bitcoin's* history — the "BIP34 height of
+    // 227,931" and the out-of-sequence indicated heights (209,921 / 490,897 /
+    // 1,983,702) are Bitcoin's, not universalmol's. universalmol's actual rule is
+    // set above: BIP30 is disabled on mainnet below BIP34Height (4141188) via
+    // legacy_mainnet_pre_bip34 and enforced strictly at/after it. The
+    // IsBIP30Repeat/IsBIP30Unspendable exception lists are universalmol-specific
+    // (the real legacy 0.15.21 duplicate coinbases). The inherited text is kept
+    // for provenance; do not act on its Bitcoin-specific heights.
+    //
+    // [Bitcoin Core, for reference]
     // Once BIP34 activated it was not possible to create new duplicate coinbases and thus other than starting
     // with the 2 existing duplicate coinbase pairs, not possible to create overwriting txs.  But by the
     // time BIP34 activated, in each of the existing pairs the duplicate coinbase had overwritten the first
@@ -3858,10 +3869,16 @@ static bool ContextualCheckBlockHeader(const CBlockHeader& block, BlockValidatio
         return state.Invalid(BlockValidationResult::BLOCK_TIME_FUTURE, "time-too-new", "block timestamp too far in the future");
     }
 
-    // Reject blocks with outdated version
-    if ((block.nVersion < 2 && DeploymentActiveAfter(pindexPrev, chainman, Consensus::DEPLOYMENT_HEIGHTINCB)) ||
-        (block.nVersion < 3 && DeploymentActiveAfter(pindexPrev, chainman, Consensus::DEPLOYMENT_DERSIG)) ||
-        (block.nVersion < 4 && DeploymentActiveAfter(pindexPrev, chainman, Consensus::DEPLOYMENT_CLTV))) {
+    // Reject blocks with outdated version. Gate on the BASE version: this is an
+    // AuxPoW chain, so the chain-id (and auxpow flag) live in the high bits of
+    // nVersion and would otherwise inflate it above the 2/3/4 thresholds, making
+    // the check a no-op. GetBaseVersion() reads the version with those high bits
+    // masked off (the header's nVersion is unchanged), so the comparison sees the
+    // real base version (Namecoin/AuxPoW convention). Diagnostics below still
+    // print the raw on-the-wire nVersion.
+    if ((block.GetBaseVersion() < 2 && DeploymentActiveAfter(pindexPrev, chainman, Consensus::DEPLOYMENT_HEIGHTINCB)) ||
+        (block.GetBaseVersion() < 3 && DeploymentActiveAfter(pindexPrev, chainman, Consensus::DEPLOYMENT_DERSIG)) ||
+        (block.GetBaseVersion() < 4 && DeploymentActiveAfter(pindexPrev, chainman, Consensus::DEPLOYMENT_CLTV))) {
             return state.Invalid(BlockValidationResult::BLOCK_INVALID_HEADER, strprintf("bad-version(0x%08x)", block.nVersion),
                                  strprintf("rejected nVersion=0x%08x block", block.nVersion));
     }

--- a/src/wallet/wallettool.cpp
+++ b/src/wallet/wallettool.cpp
@@ -202,7 +202,7 @@ bool ExecuteWalletToolFunc(const ArgsManager& args, const std::string& command)
             tfm::format(std::cerr, "%s\n", error.original);
             return ret;
         }
-        tfm::format(std::cout, "The dumpfile may contain private keys. To ensure the safety of your Bitcoin, do not share the dumpfile.\n");
+        tfm::format(std::cout, "The dumpfile may contain private keys. To ensure the safety of your UniversalMolecule, do not share the dumpfile.\n");
         return ret;
     } else if (command == "createfromdump") {
         bilingual_str error;


### PR DESCRIPTION
…s FP-determinism build guard, BIP30/wallet doc+identity cleanups

Version gate compares GetBaseVersion() so AuxPoW chain-id bits can't defeat BIP34/65/66; configure.ac refuses non-IEEE-754 FP flags (the difficulty-trend subsidy is consensus-critical). Plus BIP30 comment + wallet-message cleanups. build.sh strips -fexcess-precision=standard from the Windows MXE Makefiles (mingw g++ rejects it for C++; -ffp-contract=off and -msse2 -mfpmath=sse are kept, so it stays a no-op on x86_64).